### PR TITLE
Use PSR namespace for package and code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "http-interop/http-middleware",
+    "name": "psr/http-request-handlers",
     "description": "Common interface for HTTP server request handlers",
     "keywords": [
         "psr",
@@ -24,7 +24,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Interop\\Http\\Server\\": "src/"
+            "Psr\\Http\\Server\\": "src/"
         }
     },
     "extra": {

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Http\Server;
+namespace Psr\Http\Server;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/RequestHandlerInterface.php
+++ b/src/RequestHandlerInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Http\Server;
+namespace Psr\Http\Server;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;


### PR DESCRIPTION
As per http-interop/http-middleware#75 and http-interop/http-middleware#76
switch this package to PSR namespace for future adoption by FIG.