### PR TITLE
Added "replace" section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "php": ">=7.0",
         "psr/http-message": "^1.0"
     },
+    "replace": {
+        "http-interop/http-middleware": ">=0.5"
+    },
     "autoload": {
         "psr-4": {
             "Interop\\Http\\Server\\": "src/"


### PR DESCRIPTION
Library has exactly the same namespace and interfaces name as [`http-interop/http-middleware` 0.5.0](https://github.com/http-interop/http-middleware)

Resolves #3 