### PR TITLE
Updated psr/http-message requirements to the latest hotfix: 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I think we should required the latest version with hotfixes. I've checked changes, and these are only in PHPDocs, so maybe it's not important. What do you think?